### PR TITLE
Update manifest to allow Firefox Android

### DIFF
--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -37,9 +37,12 @@
     "storage",
     "activeTab"
   ],
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
-      "strict_min_version": "52.0"
+      "strict_min_version": "56.0"
+    },
+    "gecko_android": {
+      "strict_min_version": "113.0"
     }
   }
 }


### PR DESCRIPTION
Added 'gecko_android' section to manifest.json, used newer 'browser_specific_settings' field name, and bumped 'strict_min_version' to 56 to satisfy web-ext lint.